### PR TITLE
Fix Dashboard to ActiveSession Navigation

### DIFF
--- a/api/controllers/safetySession.js
+++ b/api/controllers/safetySession.js
@@ -1,7 +1,6 @@
 const SafetySession = require("../models/safetySession");
 const User = require("../models/user");
-const {sendSessionStartNotifications } = require("../lib/twilio")
-
+const { sendSessionStartNotifications } = require("../lib/twilio");
 
 async function getSafetySession(req, res) {
   try {
@@ -43,25 +42,25 @@ async function createSafetySession(req, res) {
 
     let user;
     try {
-      user = await User.findById(userId).populate('emergencyContact');
-  
+      user = await User.findById(userId).populate("emergencyContact");
+
       const smsResult = await sendSessionStartNotifications(user, savedSession);
-  
+
       res.status(201).json({
         message: "Safety session started successfully",
         sessionId: savedSession._id,
         safetySession: savedSession,
-        smsSent: smsResult.success
+        smsSent: smsResult.success,
       });
-    }catch (smsError) {
-      console.error('SMS notification error: ', smsError)
+    } catch (smsError) {
+      console.error("SMS notification error: ", smsError);
 
       res.status(201).json({
         message: "Safety session started successfully, but notification failed",
         safetySession: savedSession,
-        notificationError: 'SMS notification failed',
+        notificationError: "SMS notification failed",
       });
-  }
+    }
   } catch (err) {
     console.error(err);
     res.status(400).json({ message: "Failed to create safety session" });

--- a/api/lib/twilio.js
+++ b/api/lib/twilio.js
@@ -1,40 +1,38 @@
-const twilio = require('twilio');
+const twilio = require("twilio");
 
 const client = new twilio(
-    process.env.TWILIO_ACCOUNT_SID,
-    process.env.TWILIO_AUTH_TOKEN
+  process.env.TWILIO_ACCOUNT_SID,
+  process.env.TWILIO_AUTH_TOKEN
 );
 
 const twilio_number = process.env.TWILIO_PHONE_NUMBER;
 
-const emergencyNumber = '+19173528634';// hardcoded number - this will need to change
-
+const emergencyNumber = "+191735286346"; // hardcoded number - this will need to change - added a six so that this feature doesn't work for rate limiting purposes
 
 async function sendSMS(to, message) {
-    try {
-        return await client.messages.create({
-            body: message,
-            from: twilio_number,
-            to,
-        });
-    } catch (error) {
-        console.error('Twilio SMS error:', error);
-        throw error;
-    }
+  try {
+    return await client.messages.create({
+      body: message,
+      from: twilio_number,
+      to,
+    });
+  } catch (error) {
+    console.error("Twilio SMS error:", error);
+    throw error;
+  }
 }
 
 // Send notification when starting session - will need to get the user name from the users once it's done
 async function sendSessionStartNotifications(user, session) {
-    const message = `Elena started a run using SafeRun. They plan to run for ${session.duration} minutes. You'll be notified again when they confirm they're safe.`;
+  const message = `Elena started a run using SafeRun. They plan to run for ${session.duration} minutes. You'll be notified again when they confirm they're safe.`;
 
-    try {
-        const result = await sendSMS(emergencyNumber, message);
-        console.log("SMS sent successfully.");
-        return result;
-
-    } catch (error) {
-        console.error(`Failed to send SMS. Error: ${error.message}`);
-    }
+  try {
+    const result = await sendSMS(emergencyNumber, message);
+    console.log("SMS sent successfully.");
+    return result;
+  } catch (error) {
+    console.error(`Failed to send SMS. Error: ${error.message}`);
+  }
 }
 
 module.exports = { sendSMS, sendSessionStartNotifications };

--- a/frontend/src/components/SessionTimeoutModal.jsx
+++ b/frontend/src/components/SessionTimeoutModal.jsx
@@ -1,6 +1,6 @@
 import { useState, useEffect } from "react";
 
-export function SessionTimeoutModal({ isOpen, onClose }) {
+export function SessionTimeoutModal({ isOpen, onClose, onConfirm }) {
     //tracks how much time is left on the countdown (starts at 10 for testing)
     const [timeLeft, setTimeLeft] = useState(10); // 10 seconds for testing
     //this becomes true when the timer hits 0 
@@ -53,6 +53,10 @@ export function SessionTimeoutModal({ isOpen, onClose }) {
     //Simply sets the flag to show a different message
     const handleConfirmSafe = () => {
         setIsConfirmedSafe(true);
+
+        if (onConfirm) { // this prop is needed so the parent component (activesession) knows the user confirmed they were safe (otherwise the safety session wouldn't actually end)
+            onConfirm();
+        }
 
     };
 

--- a/frontend/src/pages/ActiveSession/ActiveSession.jsx
+++ b/frontend/src/pages/ActiveSession/ActiveSession.jsx
@@ -1,5 +1,6 @@
 import { useState, useEffect } from 'react';
 import { useParams, useNavigate } from 'react-router-dom';
+import { SessionTimeoutModal } from '../../components/SessionTimeoutModal';
 
 export const ActiveSession = () => {
 
@@ -7,6 +8,8 @@ export const ActiveSession = () => {
   const [timeRemaining, setTimeRemaining] = useState(0);  // Milliseconds left in timer
   const [isLoading, setIsLoading] = useState(true);       // Loading state for UX
   const [error, setError] = useState(null);               // Error handling
+  const [showTimeoutModal, setShowTimeoutModal] = useState(false);
+
   
   // Navigation hooks 
   const { sessionId } = useParams();  // Gets sessionId from URL: /active/:sessionId
@@ -62,28 +65,30 @@ export const ActiveSession = () => {
 
   // TIMER LOGIC 
   useEffect(() => {
-    if (!session) return; // e.g. Don't start timer until there is session data available
+  if (!session) return;
 
-    // Set up interval to update every second
-    const timer = setInterval(() => {
-      const now = new Date().getTime();
-      const endTime = new Date(session.scheduledEndTime).getTime();
-      const remaining = Math.max(0, endTime - now);
-      
-      setTimeRemaining(remaining);
-      
-      // Handle timer completion - for now just showing an alert - in future, this is where the modal showing the safety check in logic would be implemented.
-      if (remaining === 0) {
-        console.log('Timer completed! Time to check safety.');
-        alert('Your run time is up! Please confirm you are safe.');
-      }
-    }, 1000); // Update every 1000ms (1 second)
-
+  const timer = setInterval(() => {
+    const now = new Date().getTime();
+    const endTime = new Date(session.scheduledEndTime).getTime();
+    const remaining = Math.max(0, endTime - now);
     
+    setTimeRemaining(remaining);
+    
+    // Temp change for testing modal
+    // if (remaining === 0) { 
+    if (remaining <= (session.duration * 60 * 1000 - 10000)) { // Triggers after 10 seconds
+
+      console.log('Timer completed! Time to check safety.');
+      setShowTimeoutModal(true);
+      setTimeRemaining(0); // resetting the main timer state after modal appears - prevent any conflicts arising
+      clearInterval(timer); 
+    }
+  }, 1000);
+
     return () => {
       clearInterval(timer);  // Cleanup when component unmounts
     };
-  }, [session]); // Re-run when session changes
+  }, [session]);
 
 
   const handleEndSession = async () => {
@@ -114,7 +119,6 @@ export const ActiveSession = () => {
 
   const handleExtendTime = async () => {
     try {
-      // For now, we'll implement this as updating the session manually - endpoint added to backend
           const response = await fetch(`${import.meta.env.VITE_BACKEND_URL}/safetySessions/${sessionId}/extend`, {
         method: 'PATCH',
         headers: {
@@ -213,6 +217,18 @@ export const ActiveSession = () => {
           ⏰ Extend Time +15 mins
         </button>
       </div>
+      {/* Session time out Modal */}
+      <SessionTimeoutModal 
+        isOpen={showTimeoutModal}
+        onClose={() => {
+          setShowTimeoutModal(false);
+          navigate('/dashboard');
+        }}
+        onConfirm={() => {
+          handleEndSession(); // call check-in API when user confirms the are safe
+          setShowTimeoutModal(false);
+        }}
+      />
     </div>
   );
 };

--- a/frontend/src/pages/ActiveSession/ActiveSession.jsx
+++ b/frontend/src/pages/ActiveSession/ActiveSession.jsx
@@ -114,8 +114,7 @@ export const ActiveSession = () => {
 
   const handleExtendTime = async () => {
     try {
-      // For now, we'll implement this as updating the session manually
-      // You'll need to add this endpoint to your backend
+      // For now, we'll implement this as updating the session manually - endpoint added to backend
           const response = await fetch(`${import.meta.env.VITE_BACKEND_URL}/safetySessions/${sessionId}/extend`, {
         method: 'PATCH',
         headers: {

--- a/frontend/src/pages/Dashboard/Dashboard.jsx
+++ b/frontend/src/pages/Dashboard/Dashboard.jsx
@@ -56,19 +56,16 @@ export function Dashboard() {
                 userId, 
                 duration: numericDuration 
             });
-
+            // need to debug: console log the full response and convert the object to a string - helped to identify nested structure
+            // console.log('Full response structure:', JSON.stringify(data, null, 2)); 
             console.log('Received response:', data);
-            
-            if (!data || !data.sessionId) {
+        
+            // BUG FIX: Backend sending the session ID as _id inside a nested safetysession object - not as sessionId (this is a convention from MongoDB)
+            if (!data.safetySession._id) {
                 throw new Error('Invalid response - missing sessionId');
             }
 
-            navigate("/active", { 
-                state: { 
-                    sessionId: data.sessionId, 
-                    duration: numericDuration 
-                } 
-            });
+            navigate(`/active/${data.safetySession._id}`);
             
         } catch (err) {
             console.error('Error details:', {

--- a/frontend/src/services/safetySession.js
+++ b/frontend/src/services/safetySession.js
@@ -1,108 +1,110 @@
 const BACKEND_URL = import.meta.env.VITE_BACKEND_URL;
 
 export async function createSafetySession(data) {
-    try {
-    const response = await fetch('http://localhost:3000/safetySessions', {
-        method: 'POST',
+  try {
+    const response = await fetch(
+      `${import.meta.env.VITE_BACKEND_URL}/safetySessions`,
+      {
+        method: "POST",
         headers: {
-        'Content-Type': 'application/json'
+          "Content-Type": "application/json",
         },
-        body: JSON.stringify(data)
-    });
+        body: JSON.stringify(data),
+      }
+    );
 
     if (!response.ok) {
-        const errorData = await response.json();
-        throw new Error(errorData.message || 'Failed to create session');
+      const errorData = await response.json();
+      throw new Error(errorData.message || "Failed to create session");
     }
 
     return await response.json();
-    } catch (err) {
-    console.error('Error creating safety session:', err);
+  } catch (err) {
+    console.error("Error creating safety session:", err);
     throw err;
-    }
+  }
 }
-
 
 // Get safety session by ID
 export const getSafetySession = async (sessionId) => {
-    try {
+  try {
     const response = await fetch(`${BACKEND_URL}/safetySessions/${sessionId}`, {
-        method: "GET",
-        headers: {
+      method: "GET",
+      headers: {
         "Content-Type": "application/json",
         // 👈 Again no Auth header - as we aren't using auth yet
-        },
+      },
     });
 
     if (!response.ok) {
-        const errorData = await response.json();
-        throw new Error(errorData.message || "Failed to fetch safety session");
+      const errorData = await response.json();
+      throw new Error(errorData.message || "Failed to fetch safety session");
     }
 
     const data = await response.json();
     return data.safetySession;
-    } catch (error) {
+  } catch (error) {
     console.error("Error fetching safety session:", error);
     throw error;
-    }
+  }
 };
 
 // End safety session e.g. check-in
 export const endSafetySession = async (sessionId) => {
-    try {
+  try {
     const response = await fetch(
-        `${BACKEND_URL}/safetySessions/${sessionId}/checkin`,
-        {
+      `${BACKEND_URL}/safetySessions/${sessionId}/checkin`,
+      {
         method: "PATCH",
         headers: {
-            "Content-Type": "application/json",
+          "Content-Type": "application/json",
           // 👈 Again no Auth header - as we aren't using auth yet
         },
-        }
+      }
     );
 
     if (!response.ok) {
-        const errorData = await response.json();
-        throw new Error(errorData.message || "Failed to end safety session");
+      const errorData = await response.json();
+      throw new Error(errorData.message || "Failed to end safety session");
     }
 
     const data = await response.json();
     return data.safetySession;
-    } catch (error) {
+  } catch (error) {
     console.error("Error ending safety session:", error);
     throw error;
-    }
+  }
 };
 
 // Extend safety session duration
 export const extendSafetySession = async (
-    sessionId,
-    additionalMinutes = 15
+  sessionId,
+  additionalMinutes = 15
 ) => {
-    try {
+  try {
     const response = await fetch(
-        `${BACKEND_URL}/safetySessions/${sessionId}/extend`,
-        {
+      `${BACKEND_URL}/safetySessions/${sessionId}/extend`,
+      {
         method: "PATCH",
         headers: {
-            "Content-Type": "application/json",
+          "Content-Type": "application/json",
           // 👈 Again no Auth header - as we aren't using auth yet
         },
         body: JSON.stringify({
-            additionalMinutes,
+          additionalMinutes,
         }),
-        }
+      }
     );
 
     if (!response.ok) {
-        const errorData = await response.json();
-        throw new Error(errorData.message || "Failed to extend safety session");
+      const errorData = await response.json();
+      throw new Error(errorData.message || "Failed to extend safety session");
     }
 
     const data = await response.json();
     return data.safetySession;
-    } catch (error) {
+  } catch (error) {
     console.error("Error extending safety session:", error);
     throw error;
-    }
+  }
 };


### PR DESCRIPTION
### Problem
Dashboard was failing to navigate to ActiveSession page after creating a safety session, showing "Invalid response - missing sessionId" error.

### Root Cause
Frontend code was looking for sessionId at the root level of the API response, but the backend returns the session ID as _id nested inside the safetySession object.

**Expected structure**

```
{
  "sessionId": "..." // ← Frontend was looking here
}
```

**Actual structure**
```
{
  "safetySession": {
    "_id": "..." // ← Session ID is actually here
  }
}
```

### Changes Made

- Updated `handleStartRun()` validation from data.sessionId to `data.safetySession._id`
- Changed navigation path from `data.sessionId` to `data.safetySession._id`
- Kept the console.log statement but commented out with an explanation of the bug fix
