### PR TITLE
Fix: Reverse radial progress bar to show countdown instead of count-up

### DIFF
--- a/frontend/src/pages/ActiveSession/ActiveSession.jsx
+++ b/frontend/src/pages/ActiveSession/ActiveSession.jsx
@@ -16,9 +16,11 @@ export const ActiveSession = () => {
   const navigate = useNavigate();      
   
   // Radial progress element - need to caluclate progress percentage
+  // Old calculation was incremnting the progress bar - flipped the logic so that it noew decrements e.g. countdown style
+  // Shows remianing time - NEW (vs elapsed time - OLD)
   const progressPercentage = session 
-    ? ((session.duration * 60 * 1000 - timeRemaining) / (session.duration * 60 * 1000)) * 100 
-    : 0;
+  ? (timeRemaining / (session.duration * 60 * 1000)) * 100  // remaining divided by total 
+  : 0;
   
   // Format milliseconds into MM:SS display
   // https://stackoverflow.com/questions/29816872/how-can-i-convert-milliseconds-to-hhmmss-format-using-javascript
@@ -74,9 +76,7 @@ export const ActiveSession = () => {
     
     setTimeRemaining(remaining);
     
-    // Temp change for testing modal
-    // if (remaining === 0) { 
-    if (remaining <= (session.duration * 60 * 1000 - 10000)) { // Triggers after 10 seconds
+    if (remaining === 0) { 
 
       console.log('Timer completed! Time to check safety.');
       setShowTimeoutModal(true);

--- a/frontend/src/pages/Dashboard/Dashboard.jsx
+++ b/frontend/src/pages/Dashboard/Dashboard.jsx
@@ -3,13 +3,11 @@ import { useNavigate } from "react-router-dom";
 import { createSafetySession } from "../../services/safetySession";
 import logo from '../../assets/logo-light-grey.png';
 
-  
-
 export function Dashboard() {
-
 
     const [selectedDuration, setSelectedDuration] = useState(null); // Using state to manage selected duration
     const navigate = useNavigate();
+
 
     function durationToMinutes(duration) { // Convert duration string to minutes
         if (!duration) return null;


### PR DESCRIPTION
## 🐛 Bug Fix

### Problem
The radial progress bar on the ActiveSession page was showing **elapsed time** (0% → 100%), which is counterintuitive for a countdown timer. Users expect to see **remaining time** (100% → 0%) when timing an activity.

### Solution
- Reversed the progress percentage calculation from `(elapsed/total)` to `(remaining/total)`
- Progress bar now starts full (100%) and visually "drains" as time runs out
- Added comprehensive code comments explaining the change

### Changes Made
- **File**: `frontend/src/pages/ActiveSession/ActiveSession.jsx`
- **Line**: Progress percentage calculation (~line 18)

#### Before:
```javascript
const progressPercentage = session 
  ? ((session.duration * 60 * 1000 - timeRemaining) / (session.duration * 60 * 1000)) * 100 
  : 0;
```
  

#### After:
```javascript
const progressPercentage = session 
  ? (timeRemaining / (session.duration * 60 * 1000)) * 100
  : 0;
```


<img width="316" height="408" alt="Screenshot 2025-09-01 at 10 47 22" src="https://github.com/user-attachments/assets/34727de4-c784-4eb2-9c6e-67c7e3fb4d93" />